### PR TITLE
Move queries off the ui thread. Fixes #10.

### DIFF
--- a/app/src/main/java/adapters/DuaDetailAdapter.java
+++ b/app/src/main/java/adapters/DuaDetailAdapter.java
@@ -24,9 +24,14 @@ public class DuaDetailAdapter extends BaseAdapter {
         mList = items;
     }
 
+    public void setData(List<Dua> items) {
+        mList = items;
+        notifyDataSetChanged();
+    }
+
     @Override
     public int getCount() {
-        return mList.size();
+        return mList == null ? 0 : mList.size();
     }
 
     @Override

--- a/app/src/main/java/adapters/DuaGroupAdapter.java
+++ b/app/src/main/java/adapters/DuaGroupAdapter.java
@@ -31,6 +31,11 @@ public class DuaGroupAdapter extends BaseAdapter implements Filterable {
         mList = list;
     }
 
+    public void setData(List<Dua> list) {
+        mList = list;
+        notifyDataSetChanged();
+    }
+
     @Override
     public Filter getFilter() {
         // return a filter that filters data based on a constraint
@@ -78,7 +83,7 @@ public class DuaGroupAdapter extends BaseAdapter implements Filterable {
 
     @Override
     public int getCount() {
-        return mList.size();
+        return mList == null ? 0 : mList.size();
     }
 
     @Override

--- a/app/src/main/java/com/example/khalid/hisnulmuslim/DuaDetailActivity.java
+++ b/app/src/main/java/com/example/khalid/hisnulmuslim/DuaDetailActivity.java
@@ -4,26 +4,27 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
+import android.support.v4.app.LoaderManager;
+import android.support.v4.content.Loader;
 import android.support.v7.app.ActionBarActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.ListView;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import adapters.DuaDetailAdapter;
 import classes.Dua;
 import database.ExternalDbOpenHelper;
 import database.HisnDatabaseInfo;
+import loader.DuaDetailsLoader;
 
 
-public class DuaDetailActivity extends ActionBarActivity {
-    private String duaIdFromDuaListActivity;
-    private String duaTitleFromDuaListActivity;
-
-    private SQLiteDatabase database;
-    private ArrayList<Dua> duaDetails = new ArrayList<Dua>();
-
+public class DuaDetailActivity extends ActionBarActivity
+        implements LoaderManager.LoaderCallbacks<List<Dua>> {
+    private int duaIdFromDuaListActivity;
+    private DuaDetailAdapter adapter;
     private ListView listView;
 
     @Override
@@ -34,50 +35,10 @@ public class DuaDetailActivity extends ActionBarActivity {
 
         Intent intent = getIntent();
         Bundle bundle = intent.getExtras();
-        duaIdFromDuaListActivity = bundle.getString("dua_id");
-        duaTitleFromDuaListActivity = bundle.getString("dua_title");
-
-        ExternalDbOpenHelper dbOpenHelper = ExternalDbOpenHelper.getInstance(this);
-        database = dbOpenHelper.openDataBase();
-
-        fromDBtoArrayList();
-        fromArrayListToListView();
+        duaIdFromDuaListActivity = bundle.getInt("dua_id");
+        setTitle(bundle.getString("dua_title"));
+        getSupportLoaderManager().initLoader(0, null, this);
         //setFloatingActionButton();
-
-        this.setTitle(duaTitleFromDuaListActivity);
-    }
-
-    public void fromDBtoArrayList(){
-        Cursor duaDetailCursor = null;
-
-        try {
-            duaDetailCursor = database.query(HisnDatabaseInfo.DuaTable.TABLE_NAME,
-                    new String[]{HisnDatabaseInfo.DuaTable._ID,
-                            HisnDatabaseInfo.DuaTable.ARABIC_DUA,
-                            HisnDatabaseInfo.DuaTable.ENGLISH_TRANSLATION,
-                            HisnDatabaseInfo.DuaTable.ENGLISH_REFERENCE},
-                    HisnDatabaseInfo.DuaTable.GROUP_ID + "=" + duaIdFromDuaListActivity,
-                    null, null, null, null);
-            if (duaDetailCursor != null && duaDetailCursor.moveToFirst()) {
-                do {
-                    int reference = Integer.parseInt(duaDetailCursor.getString(0));
-                    String arabic = duaDetailCursor.getString(1);
-                    String translation = duaDetailCursor.getString(2);
-                    String book_reference = duaDetailCursor.getString(3);
-                    duaDetails.add(new Dua(reference, arabic, translation, book_reference));
-                } while (duaDetailCursor.moveToNext());
-            }
-        } finally {
-            if (duaDetailCursor != null) {
-                duaDetailCursor.close();
-            }
-        }
-    }
-
-    public void fromArrayListToListView() {
-        DuaDetailAdapter mAdapter;
-        mAdapter = new DuaDetailAdapter(this, duaDetails);
-        this.listView.setAdapter(mAdapter);
     }
 
     /*public void setFloatingActionButton() {
@@ -101,5 +62,27 @@ public class DuaDetailActivity extends ActionBarActivity {
                 return true;*/
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public Loader<List<Dua>> onCreateLoader(int id, Bundle args) {
+        return new DuaDetailsLoader(DuaDetailActivity.this, duaIdFromDuaListActivity);
+    }
+
+    @Override
+    public void onLoadFinished(Loader<List<Dua>> loader, List<Dua> data) {
+        if (adapter == null) {
+            adapter = new DuaDetailAdapter(this, data);
+            listView.setAdapter(adapter);
+        } else {
+            adapter.setData(data);
+        }
+    }
+
+    @Override
+    public void onLoaderReset(Loader<List<Dua>> loader) {
+        if (adapter != null) {
+            adapter.setData(null);
+        }
     }
 }

--- a/app/src/main/java/loader/AbstractQueryLoader.java
+++ b/app/src/main/java/loader/AbstractQueryLoader.java
@@ -1,0 +1,51 @@
+package loader;
+
+import android.content.Context;
+import android.support.v4.content.AsyncTaskLoader;
+
+import database.ExternalDbOpenHelper;
+
+public abstract class AbstractQueryLoader<T> extends AsyncTaskLoader<T> {
+    protected T mData;
+    protected final ExternalDbOpenHelper mDbHelper;
+
+    public AbstractQueryLoader(Context context) {
+        super(context);
+        mDbHelper = ExternalDbOpenHelper.getInstance(context);
+    }
+
+    @Override
+    public void deliverResult(T data) {
+        if (isReset()) {
+            return;
+        }
+
+        mData = data;
+        if (isStarted()) {
+            super.deliverResult(data);
+        }
+    }
+
+    @Override
+    protected void onStartLoading() {
+        if (mData != null) {
+            deliverResult(mData);
+        }
+
+        if (takeContentChanged() || mData == null) {
+            forceLoad();
+        }
+    }
+
+    @Override
+    protected void onStopLoading() {
+        cancelLoad();
+    }
+
+    @Override
+    protected void onReset() {
+        super.onReset();
+        onStopLoading();
+        mData = null;
+    }
+}

--- a/app/src/main/java/loader/DuaDetailsLoader.java
+++ b/app/src/main/java/loader/DuaDetailsLoader.java
@@ -1,0 +1,51 @@
+package loader;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import classes.Dua;
+import database.HisnDatabaseInfo;
+
+public class DuaDetailsLoader extends AbstractQueryLoader<List<Dua>> {
+    private int mGroup;
+
+    public DuaDetailsLoader(Context context, int group) {
+        super(context);
+        mGroup = group;
+    }
+
+    @Override
+    public List<Dua> loadInBackground() {
+        List<Dua> results = null;
+        Cursor duaDetailCursor = null;
+        try {
+            final SQLiteDatabase database = mDbHelper.getDb();
+            duaDetailCursor = database.query(HisnDatabaseInfo.DuaTable.TABLE_NAME,
+                    new String[]{HisnDatabaseInfo.DuaTable._ID,
+                            HisnDatabaseInfo.DuaTable.ARABIC_DUA,
+                            HisnDatabaseInfo.DuaTable.ENGLISH_TRANSLATION,
+                            HisnDatabaseInfo.DuaTable.ENGLISH_REFERENCE},
+                    HisnDatabaseInfo.DuaTable.GROUP_ID + "=" + mGroup,
+                    null, null, null, null);
+            results = new ArrayList<>();
+            if (duaDetailCursor != null && duaDetailCursor.moveToFirst()) {
+                do {
+                    int reference = Integer.parseInt(duaDetailCursor.getString(0));
+                    String arabic = duaDetailCursor.getString(1);
+                    String translation = duaDetailCursor.getString(2);
+                    String book_reference = duaDetailCursor.getString(3);
+                    results.add(new Dua(reference, arabic, translation, book_reference));
+                } while (duaDetailCursor.moveToNext());
+            }
+        } finally {
+            if (duaDetailCursor != null) {
+                duaDetailCursor.close();
+            }
+        }
+        return results;
+    }
+}

--- a/app/src/main/java/loader/DuaGroupLoader.java
+++ b/app/src/main/java/loader/DuaGroupLoader.java
@@ -1,0 +1,49 @@
+package loader;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import classes.Dua;
+import database.HisnDatabaseInfo;
+
+public class DuaGroupLoader extends AbstractQueryLoader<List<Dua>> {
+    public DuaGroupLoader(Context context) {
+        super(context);
+    }
+
+    @Override
+    public List<Dua> loadInBackground() {
+        List<Dua> results = null;
+        Cursor duaGroupCursor = null;
+        try {
+            final SQLiteDatabase database = mDbHelper.getDb();
+            duaGroupCursor = database.query(HisnDatabaseInfo.DuaGroupTable.TABLE_NAME,
+                    new String[]{HisnDatabaseInfo.DuaGroupTable._ID,
+                            HisnDatabaseInfo.DuaGroupTable.ENGLISH_TITLE},
+                    null,
+                    null,
+                    null,
+                    null,
+                    HisnDatabaseInfo.DuaGroupTable._ID);
+
+            if (duaGroupCursor != null && duaGroupCursor.moveToFirst()) {
+                results = new ArrayList<>();
+                do {
+                    int dua_group_id = duaGroupCursor.getInt(0);
+                    String dua_group_title = duaGroupCursor.getString(1);
+                    results.add(new Dua(dua_group_id, dua_group_title));
+                } while (duaGroupCursor.moveToNext());
+            }
+        } finally {
+            if (duaGroupCursor != null) {
+                duaGroupCursor.close();
+            }
+        }
+
+        return results;
+    }
+}


### PR DESCRIPTION
Use a loader to load data in the background instead of loading the
data on the ui thread.
