### PR TITLE
[squid:S2131] Primitives should not be boxed just for "String" conversion

### DIFF
--- a/app/src/main/java/com/khalid/hisnulmuslim/BookmarksDetailActivity.java
+++ b/app/src/main/java/com/khalid/hisnulmuslim/BookmarksDetailActivity.java
@@ -59,7 +59,7 @@ public class BookmarksDetailActivity extends AppCompatActivity
         duaIdFromDuaListActivity = bundle.getInt("dua_id");
         duaTitleFromDuaListActivity = bundle.getString("dua_title");
 
-        my_toolbar_duaGroup_number.setText(duaIdFromDuaListActivity + "");
+        my_toolbar_duaGroup_number.setText(Integer.toString(duaIdFromDuaListActivity));
         my_autofit_toolbar_title.setText(duaTitleFromDuaListActivity);
         setTitle("");
 

--- a/app/src/main/java/com/khalid/hisnulmuslim/DuaDetailActivity.java
+++ b/app/src/main/java/com/khalid/hisnulmuslim/DuaDetailActivity.java
@@ -54,7 +54,7 @@ public class DuaDetailActivity extends AppCompatActivity
         duaIdFromDuaListActivity = bundle.getInt("dua_id");
         duaTitleFromDuaListActivity = bundle.getString("dua_title");
 
-        my_toolbar_duaGroup_number.setText(duaIdFromDuaListActivity + "");
+        my_toolbar_duaGroup_number.setText(Integer.toString(duaIdFromDuaListActivity));
         my_autofit_toolbar_title.setText(duaTitleFromDuaListActivity);
         setTitle("");
 

--- a/app/src/main/java/com/khalid/hisnulmuslim/adapter/BookmarksDetailAdapter.java
+++ b/app/src/main/java/com/khalid/hisnulmuslim/adapter/BookmarksDetailAdapter.java
@@ -153,8 +153,8 @@ public class BookmarksDetailAdapter extends BaseAdapter {
                     int sql_position = Integer.parseInt(mHolder.tvDuaNumber.getText().toString());
                     sql_position -= 1;
 
-                    Log.d("KHALID_NUMBER", sql_position + "");
-                    Log.d("KHALID_isFav", isFav + "");
+                    Log.d("KHALID_NUMBER", Integer.toString(sql_position));
+                    Log.d("KHALID_isFav", Boolean.toString(isFav));
 
                     deleteRow(finalPosition);
 

--- a/app/src/main/java/com/khalid/hisnulmuslim/adapter/BookmarksDetailRecycleAdapter.java
+++ b/app/src/main/java/com/khalid/hisnulmuslim/adapter/BookmarksDetailRecycleAdapter.java
@@ -155,7 +155,7 @@ public class BookmarksDetailRecycleAdapter extends RecyclerView.Adapter<Bookmark
                 int sql_position = Integer.parseInt(finalmHolder.tvDuaNumber.getText().toString());
                 // sql_position -= 1;
 
-                Log.d("K12_sqlPosition", sql_position + "");
+                Log.d("K12_sqlPosition", Integer.toString(sql_position));
 
                 deleteRow(finalPosition);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131 - “Primitives should not be boxed just for "String" conversion”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.
Ayman Abdelghany.
